### PR TITLE
Release waffle 0.1.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waffle"
-version = "0.0.44"
+version = "0.1.0"
 description = "Wasm Analysis Framework For Lightweight Experiments"
 authors = ["Chris Fallin <chris@cfallin.org>"]
 license = "Apache-2.0 WITH LLVM-exception"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ description = "Wasm Analysis Framework For Lightweight Experiments"
 authors = ["Chris Fallin <chris@cfallin.org>"]
 license = "Apache-2.0 WITH LLVM-exception"
 edition = "2018"
+repository = "https://github.com/bytecodealliance/waffle"
 
 [dependencies]
 wasmparser = "0.212"


### PR DESCRIPTION
Now that waffle is under the BA umbrella, let's cut a new release with the fully reviewed code and from the new origin.