### PR TITLE
Handle MemoryFill and MemoryCopy operators

### DIFF
--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -1434,7 +1434,9 @@ impl<'a, 'b> FunctionBodyBuilder<'a, 'b> {
             | wasmparser::Operator::CallRef { .. }
             | wasmparser::Operator::RefIsNull
             | wasmparser::Operator::RefNull { .. }
-            | wasmparser::Operator::RefFunc { .. } => {
+            | wasmparser::Operator::RefFunc { .. }
+            | wasmparser::Operator::MemoryFill { .. }
+            | wasmparser::Operator::MemoryCopy { .. } => {
                 self.emit(Operator::try_from(&op).unwrap(), loc)?
             }
 


### PR DESCRIPTION
I found I needed this to `weval` spidermonkey using latest stable release 147_0_4 and `wasi-sdk@30`.