### PR TITLE
Fix `Module::display` to print function bodies again

### DIFF
--- a/src/ir/display.rs
+++ b/src/ir/display.rs
@@ -322,14 +322,16 @@ impl<'a, PD: PrintDecorator> Display for ModuleDisplay<'a, PD> {
                         sig_strs.get(&sig).unwrap()
                     )?;
 
-                    if let Some(decorator) = &self.decorators {
-                        let decorator = &(*decorator)(func);
-                        writeln!(
-                            f,
-                            "{}",
-                            body.display_with_decorator("    ", Some(self.module), decorator)
-                        )?;
-                    }
+                    let decorator = self
+                        .decorators
+                        .as_ref()
+                        .map(|decorator_fn| decorator_fn(func));
+
+                    writeln!(
+                        f,
+                        "{}",
+                        body.display_with_decorator("    ", Some(self.module), decorator.as_ref())
+                    )?;
                 }
                 FuncDecl::Lazy(sig, name, reader) => {
                     writeln!(

--- a/src/ir/func.rs
+++ b/src/ir/func.rs
@@ -471,14 +471,14 @@ impl FunctionBody {
         &'a self,
         indent: &'a str,
         module: Option<&'a Module>,
-        decorator: &'a PD,
+        decorator: Option<&'a PD>,
     ) -> FunctionBodyDisplay<'a, PD> {
         FunctionBodyDisplay {
             body: self,
             indent,
             verbose: false,
             module,
-            decorator: Some(&decorator),
+            decorator: decorator,
         }
     }
 


### PR DESCRIPTION
The change which added `PrintDecorator` broke the default `Module::display` by not showing the function bodies anymore when no `PrintDecorator` was provided.

This change always invokes the body display function again, now with the optional `PrintDecorator`.

This does change the signature of `FunctionBody::display_with_decorator` to take an `Option<&'a PD>` now, which is not consistent with the function convention on `Module`, but this needs a display function on FunctionBody which takes an `Option`.

Alternatively I can change this to invoke `FunctionBody::display` or `FunctionBody::display_with_decorator` depending on the presence/absence of a decorator, but that feels less ideal.