### PR TITLE
Fix multi-value operator result order.

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -268,7 +268,7 @@ impl<'a> WasmFuncBackend<'a> {
                 }
                 self.lower_op(op, func);
                 if root {
-                    for &local in &ctx.locals.values[value] {
+                    for &local in ctx.locals.values[value].iter().rev() {
                         func.instruction(
                             &wasm_encoder::Instruction::LocalSet(local.index() as u32),
                         );

--- a/tests/roundtrip/multi-value-call.wat
+++ b/tests/roundtrip/multi-value-call.wat
@@ -1,0 +1,9 @@
+(module
+  (func (export "f") (param i32 i32) (result i32 i32)
+        local.get 0
+        local.get 1
+        call 1)
+
+  (func (param i32 i32) (result i32 i32)
+        local.get 0
+        local.get 1))


### PR DESCRIPTION
The localification (regalloc and local.get/local.set insertion) pass previously handled multi-value operators with results in the incorrect (reversed) order. This hadn't been caught yet as multi-value results had apparently not yet been used in a nontrivial use-case nor hit by a fuzzer. This PR fixes the order and adds a roundtrip test (the idempotency/fixpoint condition of the roundtrip test will fail if the results are reversed as they will flip on each roundtrip).