### PR TITLE
Use FxHashMap/FxHashSet rather than std HashMap everywhere.

### DIFF
--- a/src/backend/localify.rs
+++ b/src/backend/localify.rs
@@ -5,8 +5,8 @@ use crate::backend::treeify::Trees;
 use crate::cfg::CFGInfo;
 use crate::entity::{EntityVec, PerEntity};
 use crate::ir::{Block, FunctionBody, Local, Type, Value, ValueDef};
+use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use smallvec::{smallvec, SmallVec};
-use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 
 #[derive(Clone, Debug, Default)]
@@ -242,13 +242,13 @@ impl<'a> Context<'a> {
         ranges.sort_unstable_by_key(|(val, range)| (range.start, *val));
 
         // Keep a list of expiring Locals by expiry point.
-        let mut expiring: HashMap<usize, SmallVec<[(Type, Local); 8]>> = HashMap::new();
+        let mut expiring: HashMap<usize, SmallVec<[(Type, Local); 8]>> = HashMap::default();
 
         // Iterate over allocation space, processing range starts (at
         // which point we allocate) and ends (at which point we add to
         // the freelist).
         let mut range_idx = 0;
-        let mut freelist: HashMap<Type, Vec<Local>> = HashMap::new();
+        let mut freelist: HashMap<Type, Vec<Local>> = HashMap::default();
 
         for i in 0..self.points {
             // Process ends. (Ends are exclusive, so we do them

--- a/src/backend/reducify.rs
+++ b/src/backend/reducify.rs
@@ -150,10 +150,11 @@
 
 use crate::entity::EntityRef;
 use crate::{cfg::CFGInfo, cfg::RPOIndex, entity::PerEntity, Block, FunctionBody, Value, ValueDef};
+use fxhash::FxHashSet as HashSet;
 use fxhash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use std::borrow::Cow;
-use std::collections::{HashSet, VecDeque};
+use std::collections::VecDeque;
 
 pub struct Reducifier<'a> {
     body: &'a FunctionBody,

--- a/src/backend/stackify.rs
+++ b/src/backend/stackify.rs
@@ -12,7 +12,7 @@
 use crate::cfg::CFGInfo;
 use crate::entity::EntityRef;
 use crate::ir::{Block, BlockTarget, FunctionBody, Terminator, Type, Value};
-use std::collections::HashSet;
+use fxhash::FxHashSet as HashSet;
 use std::convert::TryFrom;
 
 #[derive(Clone, Debug)]
@@ -134,9 +134,9 @@ impl<'a, 'b> Context<'a, 'b> {
         body: &FunctionBody,
         cfg: &CFGInfo,
     ) -> anyhow::Result<(HashSet<Block>, HashSet<Block>)> {
-        let mut loop_headers = HashSet::new();
-        let mut branched_once = HashSet::new();
-        let mut merge_nodes = HashSet::new();
+        let mut loop_headers = HashSet::default();
+        let mut branched_once = HashSet::default();
+        let mut merge_nodes = HashSet::default();
 
         for (block_rpo, &block) in cfg.rpo.entries() {
             for &succ in &body.blocks[block].succs {

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -5,7 +5,7 @@ use crate::ir::*;
 use crate::ops::Operator;
 use smallvec::{smallvec, SmallVec};
 
-use std::collections::HashMap;
+use fxhash::FxHashMap as HashMap;
 
 /// How large do we allow a Wasm memory to be when interpreting? Limit
 /// the size somewhat (apply an implementation limit) so we do not
@@ -156,7 +156,7 @@ impl InterpContext {
         let mut frame = InterpStackFrame {
             func,
             cur_block: body.entry,
-            values: HashMap::new(),
+            values: HashMap::default(),
         };
 
         for (&arg, &(_, blockparam)) in args.iter().zip(body.blocks[body.entry].params.iter()) {

--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -4,8 +4,8 @@ use crate::declare_entity;
 use crate::entity::EntityVec;
 #[cfg(feature = "dwarf")]
 use addr2line::gimli;
+use fxhash::FxHashMap as HashMap;
 use std::collections::hash_map::Entry as HashEntry;
-use std::collections::HashMap;
 
 declare_entity!(SourceFile, "file");
 declare_entity!(SourceLoc, "loc");

--- a/src/ir/display.rs
+++ b/src/ir/display.rs
@@ -2,7 +2,7 @@
 
 use super::{Func, FuncDecl, FunctionBody, Module, SourceLoc, ValueDef};
 use crate::entity::EntityRef;
-use std::collections::HashMap;
+use fxhash::FxHashMap as HashMap;
 use std::fmt::{self, Display, Formatter, Result as FmtResult};
 
 /// Hooks to print information after instruction, before and after blocks
@@ -253,7 +253,7 @@ impl<'a, PD: PrintDecorator> Display for ModuleDisplay<'a, PD> {
         if let Some(func) = self.module.start_func {
             writeln!(f, "    start = {}", func)?;
         }
-        let mut sig_strs = HashMap::new();
+        let mut sig_strs = HashMap::default();
         for (sig, sig_data) in self.module.signatures.entries() {
             let arg_tys = sig_data
                 .params

--- a/src/ir/func.rs
+++ b/src/ir/func.rs
@@ -12,7 +12,7 @@ use crate::pool::{ListPool, ListRef};
 use crate::Operator;
 use anyhow::Result;
 use fxhash::FxHashMap;
-use std::collections::HashSet;
+use fxhash::FxHashSet as HashSet;
 
 /// A declaration of a function: there is one `FuncDecl` per `Func`
 /// index.

--- a/src/passes/maxssa.rs
+++ b/src/passes/maxssa.rs
@@ -7,7 +7,8 @@
 use crate::cfg::CFGInfo;
 use crate::entity::PerEntity;
 use crate::ir::{Block, FunctionBody, Value, ValueDef};
-use std::collections::{BTreeSet, HashMap, HashSet};
+use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use std::collections::BTreeSet;
 
 pub(crate) fn run(body: &mut FunctionBody, cut_blocks: Option<HashSet<Block>>, cfg: &CFGInfo) {
     MaxSSAPass::new(cut_blocks).run(body, cfg);
@@ -30,7 +31,7 @@ impl MaxSSAPass {
         Self {
             cut_blocks,
             new_args: PerEntity::default(),
-            value_map: HashMap::new(),
+            value_map: HashMap::default(),
         }
     }
 


### PR DESCRIPTION
Significant performance improvement in some workloads that compile many large functions.